### PR TITLE
매직넘버 대신 이름 사용

### DIFF
--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -16,7 +16,7 @@ FROM nginx:1.17.5-alpine
 WORKDIR /usr/src/nginx
 
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=0 /usr/src/client/build ./code-avengers
+COPY --from=build-react /usr/src/client/build ./code-avengers
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
-  도커 multi-stage build 에서 이전 stage artifact를 가져오기 위해 `--from=0`를 사용했었는데
-  AS <NAME> 으로 지정한 이름을 대신 사용하도록 수정