### PR TITLE
travis.ci 실행 전략 변경

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,40 +10,68 @@ cache: npm
 services:
     - docker
 
+branches:
+    only:
+        - master
+        - develop
+
 jobs:
     include:
         - stage: 'TEST'
-          name: 'Front-end test & build'
+          if: type = pull_request
+          name: 'Front-end test'
           before_install:
               - cd ./client
-              - echo "$NCP_SECRET_KEY" | docker login -u "$NCP_ACCESS_KEY_ID" dev-2019-01.kr.ncr.ntruss.com --password-stdin
           install:
               - npm install
           script:
               - npm test
-              - docker build -t dev-2019-01.kr.ncr.ntruss.com/front-end . -f ../docker/client.Dockerfile
-              - docker push dev-2019-01.kr.ncr.ntruss.com/front-end
 
-        - name: 'Back-end test & build'
+        - name: 'Back-end test'
+          if: type = pull_request
           before_install:
               - cd ./server
-              - echo "$NCP_SECRET_KEY" | docker login -u "$NCP_ACCESS_KEY_ID" dev-2019-01.kr.ncr.ntruss.com --password-stdin
           install:
               - npm install
           script:
+              - npm test
+        
+
+        - stage: 'BUILD'
+          name: 'Front-end build'
+          if: type = push
+          before_script:
+              - cd ./client
+              - echo "$NCP_SECRET_KEY" | docker login -u "$NCP_ACCESS_KEY_ID" dev-2019-01.kr.ncr.ntruss.com --password-stdin
+          script:
+              - docker build -t dev-2019-01.kr.ncr.ntruss.com/front-end . -f ../docker/client.Dockerfile
+          after_success:
+              - docker push dev-2019-01.kr.ncr.ntruss.com/front-end
+
+        - name: 'Back-end build'
+          if: type = push
+          before_script:
+              - cd ./server
+              - echo "$NCP_SECRET_KEY" | docker login -u "$NCP_ACCESS_KEY_ID" dev-2019-01.kr.ncr.ntruss.com --password-stdin
+          script:
               - docker build -t dev-2019-01.kr.ncr.ntruss.com/back-end . -f ../docker/server.Dockerfile
+          after_success:
               - docker push dev-2019-01.kr.ncr.ntruss.com/back-end
 
-        - name: 'MySQL test & build'
-          before_install:
+        - name: 'Mysql build'
+          if: type = push
+          before_script:
               - cd ./mysql
               - echo "$NCP_SECRET_KEY" | docker login -u "$NCP_ACCESS_KEY_ID" dev-2019-01.kr.ncr.ntruss.com --password-stdin
           script:
               - docker build -t dev-2019-01.kr.ncr.ntruss.com/mysql . -f ../docker/mysql.Dockerfile
+          after_success:
               - docker push dev-2019-01.kr.ncr.ntruss.com/mysql
+
 
         - stage: 'DEPLOY'
           name: 'Dev-server deploy'
+          if: (type = push) AND (branch = develop)
           script:
               - sudo apt-get install sshpass
               - sshpass -p "$DEV_SERVER_SSH_PW" ssh -p 2222 -o StrictHostKeyChecking=no root@"$DEV_SERVER_IP" ./deploy.sh

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "webpack --mode production; node ./bin/www"
+    "start": "webpack --mode production; node ./bin/www",
+    "test": "echo skip-test"
   },
   "dependencies": {
     "debug": "~2.6.9",


### PR DESCRIPTION
기존 pull request 에서 CI/CD 되는 것에서 pull request, push 마다 CI/CD가 선택적으로 진행되도록 수정함.
변경안은 다음과 같음.

- develop, master로 pull request: frontend, backend 테스트
- develop, master로 push(= merge): frontend, backend, mysql 등 도커 이미지 빌드 후 배포


===
추가 설명
1. server/package.json 수정 이유
  - travis에서 npm test 실행하도록 했기 때문 