### PR TITLE
nginx에서 websocket 연결 안되는 현상 해결

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -17,8 +17,20 @@ server {
     }
 
     location /socket.io {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-NginX-Proxy true;
+
         proxy_pass http://app/socket.io;
+        proxy_redirect off;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
+    # https://stackoverflow.com/questions/29043879/socket-io-with-nginx
 
     # location /admin {
     #     proxy_pass http://server/admin;

--- a/client/src/class/socket.js
+++ b/client/src/class/socket.js
@@ -7,12 +7,14 @@ const isFunction = (callback) => typeof callback === 'function';
 class SocketContainer {
   constructor() {
     this.socket = undefined;
-    this.url = process.env.NODE_ENV === 'production' ? 'http://45.119.146.251/socket.io' : 'http://localhost:3000';
     this.connect();
   }
 
   connect() {
-    this.socket = socketio.connect(this.url, { transports: ['websocket'] });
+    this.socket = (
+      process.env.NODE_ENV === 'production'
+        ? socketio({ path: '/socket.io', transports: ['websocket'] })
+        : socketio('http://localhost:3000', { transports: ['websocket'] }));
   }
 
   disconnect() {


### PR DESCRIPTION
nginx에서 websocket proxy 문제로 인해 연결이 안되던 현상 해결함.
nginx의 연결 설정을 변경하고, client에서 연결 시 옵션에 path를 줌.
아마 path 옵션 설정이 매우 큰 역할을 한 것 같으나, 그 이유는 아직 찾지 못함..

그래도 해결되서 다행..
실제 개발 서버에서도 동일하게 적용되기를 기도함...