### PR TITLE
배포 서버에서 실행 시, DB 상태 확인하지 않는 오류 수정

### DIFF
--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -7,6 +7,11 @@ COPY ./package.json ./
 RUN npm install --production
 COPY . .
 
-CMD ["npm", "run", "build"]
+## THE LIFE SAVER
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait /wait
+RUN chmod +x /wait
 
+## Launch the wait tool and then your application
+CMD /wait && npm run build
+# https://dev.to/hugodias/wait-for-mongodb-to-start-on-docker-3h8b
 # https://github.com/bear2u/docker-exam-react

--- a/script/docker-compose.yml
+++ b/script/docker-compose.yml
@@ -1,20 +1,5 @@
 version: "3.5"
 services:
-    server:
-        image: dev-2019-01.kr.ncr.ntruss.com/back-end
-        networks:
-            - backend
-
-    nginx_client:
-        restart: always
-        image: dev-2019-01.kr.ncr.ntruss.com/front-end
-        ports:
-            - "80:80"
-        depends_on:
-            - server
-        networks:
-            - backend
-
     db:
         image: dev-2019-01.kr.ncr.ntruss.com/mysql
         environment:
@@ -26,6 +11,27 @@ services:
             - mysql_secret
         ports:
             - "3306:3306"
+        networks:
+            - backend
+
+    server:
+        restart: always
+        image: dev-2019-01.kr.ncr.ntruss.com/back-end
+        depends_on:
+            - db
+        environment:
+            DB_HOST_IP: db
+            WAIT_HOSTS: db:3306
+        networks:
+            - backend
+
+    nginx_client:
+        restart: always
+        image: dev-2019-01.kr.ncr.ntruss.com/front-end
+        ports:
+            - "80:80"
+        depends_on:
+            - server
         networks:
             - backend
 

--- a/server/database/connection.js
+++ b/server/database/connection.js
@@ -1,9 +1,7 @@
 import mysql from 'mysql2';
 
-const LOCALHOST = '127.0.0.1';
-
 const db = mysql.createPool({
-  host: process.env.NODE_ENV === 'production' ? LOCALHOST : process.env.DB_HOST,
+  host: process.env.NODE_ENV === 'production' ? process.env.DB_HOST_IP : process.env.DB_HOST,
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   port: process.env.DB_PORT,


### PR DESCRIPTION
DB 상태 확인하지 않고, 요청 시 null 배열이 생기는 등 오류가 발생하기 때문에 이를 해결하기 위해,
docker-compose-wait를 사용하여 확인 후 실행하도록 수정함.