### PR TITLE
[bugfix/socket event overlap] room, lobby 재입장 시 소켓 이벤트를 중복으로 받는 문제 해결

### DIFF
--- a/client/src/components/Lobby/index.js
+++ b/client/src/components/Lobby/index.js
@@ -127,12 +127,19 @@ const Lobby = () => {
     }
 
     socket.onEnterLobby(updateCurrentRoomInfos);
-    socket.emitEnterLobby();
     socket.onCreateRoom(enterCreatedRoom);
     socket.onRoomIsCreated(updateCreatedRoom);
     socket.onUpdateRoomInfo(updateRoomInfo);
     socket.onKnockRoom(enterRoom);
-    socket.onDisconnect(() => history.replace('/'));
+    socket.emitEnterLobby();
+
+    return () => {
+      socket.offEnterLobby();
+      socket.offCreateRoom();
+      socket.offRoomIsCreated();
+      socket.offUpdateRoomInfo();
+      socket.offKnockRoom();
+    };
   }, []);
 
   return (

--- a/client/src/components/Room/ChatArea/Info.js
+++ b/client/src/components/Room/ChatArea/Info.js
@@ -70,6 +70,14 @@ const Info = () => {
     socket.onLeaveRoom(enterLobby);
 
     return () => {
+      socket.offStartGame();
+      socket.offEndGame();
+      socket.offEnterRoom();
+      socket.offEnterNewUser();
+      socket.offLeaveUser();
+      socket.offEndRound();
+      socket.offStartRound();
+      socket.offLeaveRoom();
       clearTimeout(lastTimerId);
     };
   }, []);

--- a/client/src/components/Room/ChatArea/Log.js
+++ b/client/src/components/Room/ChatArea/Log.js
@@ -24,6 +24,10 @@ const Log = () => {
 
   useEffect(() => {
     socket.onChatMessage(addChat);
+
+    return () => {
+      socket.offChatMessage();
+    };
   }, []);
 
   useEffect(() => {

--- a/client/src/components/Room/ChatArea/RoomName/index.js
+++ b/client/src/components/Room/ChatArea/RoomName/index.js
@@ -35,7 +35,9 @@ const RoomName = () => {
 
   useEffect(() => {
     socket.onEnterRoom(setup);
+
     return () => {
+      socket.offEnterRoom();
       window.cancelAnimationFrame(requestId);
     };
   }, []);

--- a/client/src/components/Room/GameArea/DashBoard.js
+++ b/client/src/components/Room/GameArea/DashBoard.js
@@ -129,6 +129,12 @@ const DashBoard = ({ buttonClickSound }) => {
     socket.onStartGame(readyGame);
 
     return () => {
+      socket.offEnterRoom();
+      socket.offLeaveUser();
+      socket.offStartRound();
+      socket.offEndRound();
+      socket.offEndGame();
+      socket.offStartGame();
       clearTimeout(lastTimerId);
     };
   }, []);

--- a/client/src/components/Room/GameArea/Field.js
+++ b/client/src/components/Room/GameArea/Field.js
@@ -99,6 +99,13 @@ const Field = () => {
     socket.onEndGame(updateCharacters);
 
     return () => {
+      socket.offStartRound();
+      socket.offEnterRoom();
+      socket.offEnterNewUser();
+      socket.offMove();
+      socket.offEndRound();
+      socket.offLeaveUser();
+      socket.offEndGame();
       clearTimeout(lastTimerId);
     };
   }, []);

--- a/client/src/components/Room/index.js
+++ b/client/src/components/Room/index.js
@@ -41,6 +41,10 @@ const Room = () => {
     () => backgroundMusic.play(), ROOM.WAITING_SOUND_TIME_MS,
   );
 
+  const notifyEndGame = ({ isOwner }) => {
+    if (isOwner) socket.emitEndGame(roomId);
+  };
+
   useEffect(() => {
     backgroundMusic.autoplay = true;
     backgroundMusic.loop = true;
@@ -50,13 +54,13 @@ const Room = () => {
     if (socket.isConnected() === false) history.replace('/');
     socket.emitEnterRoom(roomId);
     socket.onStartGame(playStartSound);
-    socket.onEndGame(({ isOwner }) => {
-      if (isOwner) socket.emitEndGame(roomId);
-      playEndSound();
-    });
+    socket.onEndGame(playEndSound);
+    socket.onEndGame(notifyEndGame);
     return () => {
-      socket.emitLeaveRoom();
       backgroundMusic.pause();
+      socket.offStartGame();
+      socket.offEndGame();
+      socket.emitLeaveRoom();
     };
   }, []);
 

--- a/client/src/constants/socket-event.js
+++ b/client/src/constants/socket-event.js
@@ -11,7 +11,6 @@ const EVENT = {
   START_GAME: 'start_game',
   START_ROUND: 'start_round',
   END_ROUND: 'end_round',
-  NOT_END_ROUND: 'not_end_round',
   END_GAME: 'end_game',
   MOVE: 'move',
   CHAT_MESSAGE: 'chat_message',

--- a/client/src/modules/socket.js
+++ b/client/src/modules/socket.js
@@ -149,6 +149,26 @@ class SocketContainer {
     this.socket.off(eventName);
   }
 
+  offEnterLobby() {
+    this._off(EVENT.ENTER_LOBBY);
+  }
+
+  offCreateRoom() {
+    this._off(EVENT.CREATE_ROOM);
+  }
+
+  offRoomIsCreated() {
+    this._off(EVENT.ROOM_IS_CREATED);
+  }
+
+  offUpdateRoomInfo() {
+    this._off(EVENT.UPDATE_ROOM_INFO);
+  }
+
+  offKnockRoom() {
+    this._off(EVENT.KNOCK_ROOM);
+  }
+
   offStartGame() {
     this._off(EVENT.START_GAME);
   }

--- a/client/src/modules/socket.js
+++ b/client/src/modules/socket.js
@@ -143,6 +143,51 @@ class SocketContainer {
   onDisconnect(callback) {
     this._on(EVENT.DISCONNECT, callback);
   }
+
+  _off(eventName) {
+    if (this.socket === undefined) return;
+    this.socket.off(eventName);
+  }
+
+  offStartGame() {
+    this._off(EVENT.START_GAME);
+  }
+
+  offEndGame() {
+    this._off(EVENT.END_GAME);
+  }
+
+  offStartRound() {
+    this._off(EVENT.START_ROUND);
+  }
+
+  offEndRound() {
+    this._off(EVENT.END_ROUND);
+  }
+
+  offLeaveUser() {
+    this._off(EVENT.LEAVE_USER);
+  }
+
+  offEnterRoom() {
+    this._off(EVENT.ENTER_ROOM);
+  }
+
+  offEnterNewUser() {
+    this._off(EVENT.ENTER_NEW_USER);
+  }
+
+  offMove() {
+    this._off(EVENT.MOVE);
+  }
+
+  offLeaveRoom() {
+    this._off(EVENT.LEAVE_ROOM);
+  }
+
+  offChatMessage() {
+    this._off(EVENT.CHAT_MESSAGE);
+  }
 }
 
 const socket = new SocketContainer();

--- a/server/constants/socket-event.js
+++ b/server/constants/socket-event.js
@@ -11,7 +11,6 @@ const EVENT = {
   START_GAME: 'start_game',
   START_ROUND: 'start_round',
   END_ROUND: 'end_round',
-  NOT_END_ROUND: 'not_end_round',
   END_GAME: 'end_game',
   MOVE: 'move',
   CHAT_MESSAGE: 'chat_message',

--- a/server/models/room.js
+++ b/server/models/room.js
@@ -313,10 +313,6 @@ class Room {
     return dropUsers;
   }
 
-  // emit: not_end_round / 모든 유저 / 정답, 재도전 안내
-  // 현재 있어야하나, 고민 중...
-  _notEndRound() {}
-
   // emit: end_game / 모든 유저 / 우승자 닉네임, 게임 상태, 모든 캐릭터 + 닉네임 + 위치
   _endGame() {
     const characterList = [];

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -162,10 +162,6 @@ class User {
     this.socket.emit(EVENT.END_ROUND, data);
   }
 
-  emitNotEndRound(data) {
-    this.socket.emit(EVENT.NOT_END_ROUND, data);
-  }
-
   emitEndGame(data) {
     this.socket.emit(EVENT.END_GAME, data);
   }


### PR DESCRIPTION
- room에서 퇴장 후 같은 room에 재입장했을 경우, 그리고 lobby에 재입장한 경우: 재입장한 횟수만큼 소켓 이벤트를 받는 문제 발견
- unmount하는 시점에, 받던 socket on들을 모두 off해주는 방법으로 해결했습니다.
- 이 문제 해결로 다음 버그가 해결되었습니다.
    - 플레이어 및 관전자 수 표시가 맞지 않는 버그 (음수 등)
    - sound가 겹쳐서 실행되는 버그